### PR TITLE
feat: extract SafeArea logic to LayoutWrapper and flatten design tokens

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,10 @@
 import { Stack } from 'expo-router';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <SafeAreaProvider>
+      <Stack screenOptions={{ headerShown: false }} />
+    </SafeAreaProvider>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,14 @@
-import { Text, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
+import tw from '@/lib/design/tw';
 
 export default function Index() {
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <Text>Welcome to Noroo :) </Text>
+    <View>
+      <TouchableOpacity style={tw`mt-20 bg-primary py-md px-lg rounded-lg`}>
+        <Text style={tw`text-coral px-25 text-base font-semibold`}>
+          Welcome to Nuroo
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/components/LayoutWrappe/LayoutWrapper.tsx
+++ b/components/LayoutWrappe/LayoutWrapper.tsx
@@ -1,0 +1,36 @@
+// components/LayoutWrapper.tsx
+import React, { ReactNode } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, StyleSheet } from 'react-native';
+
+import designTokens from '@/lib/design/tokens';
+
+interface LayoutWrapperProps {
+  children: ReactNode;
+  backgroundColor?: string;
+}
+
+const LayoutWrapper = ({ children, backgroundColor }: LayoutWrapperProps) => {
+  return (
+    <SafeAreaView
+      style={[
+        styles.safeArea,
+        { backgroundColor: backgroundColor || designTokens.colors.background },
+      ]}
+    >
+      <View style={styles.container}>{children}</View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    padding: Number(designTokens.spacing.md),
+  },
+});
+
+export default LayoutWrapper;

--- a/lib/design/tokens.ts
+++ b/lib/design/tokens.ts
@@ -1,0 +1,77 @@
+// lib/design/tokens.ts
+
+export const colors = {
+  primary: '#1D2B64',
+  teal: '#4FD1C7',
+  coral: '#FF9F8A',
+  blue: '#87CEEB',
+  background: '#F9FAFB',
+  white: '#FFFFFF',
+  text: '#1D2B64',
+  success: '#10B981',
+  warning: '#F59E0B',
+  error: '#EF4444',
+  info: '#3B82F6',
+  50: '#F9FAFB',
+  100: '#F3F4F6',
+  200: '#E5E7EB',
+  300: '#D1D5DB',
+  400: '#9CA3AF',
+  500: '#6B7280',
+  600: '#4B5563',
+  700: '#374151',
+  800: '#1F2937',
+  900: '#111827',
+};
+
+export const fontSize = {
+  xs: '12',
+  sm: '14',
+  base: '16',
+  md: '18',
+  lg: '20',
+  xl: '24',
+  '2xl': '30',
+  '3xl': '36',
+};
+
+export const spacing = {
+  xs: '4',
+  sm: '8',
+  md: '16',
+  lg: '24',
+  xl: '32',
+  '2xl': '48',
+  '3xl': '64',
+};
+
+export const borderRadius = {
+  none: '0',
+  sm: '4',
+  md: '8',
+  lg: '12',
+  xl: '16',
+  '2xl': '24',
+  full: '9999',
+};
+
+export const fontFamily = {
+  sans: ['System', 'Inter'],
+};
+
+export const shadows = {
+  sm: '0px 1px 2px rgba(0, 0, 0, 0.05)',
+  md: '0px 4px 6px rgba(0, 0, 0, 0.1)',
+  lg: '0px 10px 15px rgba(0, 0, 0, 0.1)',
+};
+
+export const designTokens = {
+  colors,
+  fontSize,
+  spacing,
+  borderRadius,
+  fontFamily,
+  shadows,
+};
+
+export default designTokens;

--- a/lib/design/tw.ts
+++ b/lib/design/tw.ts
@@ -1,0 +1,16 @@
+import { create } from 'twrnc';
+import { designTokens } from './tokens';
+
+const tw = create({
+  theme: {
+    extend: {
+      colors: designTokens.colors,
+      fontSize: designTokens.fontSize,
+      spacing: designTokens.spacing,
+      borderRadius: designTokens.borderRadius,
+      fontFamily: designTokens.fontFamily,
+    },
+  },
+});
+
+export default tw;


### PR DESCRIPTION
### 🔍 What’s been done?

_A short summary of the issue and what was changed._

Extracted SafeAreaView, background color, and padding logic into a reusable LayoutWrapper component

Flattened designTokens.colors by removing nested neutral object

Updated Tailwind configuration in lib/tw.ts to match new design tokens

This refactor improves code clarity, flexibility, and scalability. Each screen can now decide whether it needs a SafeAreaView, ScrollView, or other layout wrappers independently.

### ✅ Checklist

- [✅] Code is formatted & linted
- [✅] Only relevant files are changed
- [✅] PR title follows conventional commits (e.g. `fix:`, `feat:`, `docs:`)
- [✅] I’ve tested my changes and reviewed the diff before submitting

Closes #21 
