### PR TITLE
feat: ui  add reusable Input component with type support

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,14 +1,13 @@
-import { Text, TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 import tw from '@/lib/design/tw';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 export default function Index() {
   return (
-    <View>
-      <TouchableOpacity style={tw`mt-20 bg-primary py-md px-lg rounded-lg`}>
-        <Text style={tw`text-coral px-25 text-base font-semibold`}>
-          Welcome to Nuroo
-        </Text>
-      </TouchableOpacity>
+    <View style={tw`flex-1 justify-center items-center bg-white px-4`}>
+      <Button style={tw`px-8 py-4`} title="Hello World" variant="teal" />
+      <Input placeholder="Text" type="text" variant="outlined" />
     </View>
   );
 }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,42 @@
+import tw from '@/lib/design/tw';
+import React from 'react';
+import { TouchableOpacity, Text, TouchableOpacityProps } from 'react-native';
+
+type ButtonProps = TouchableOpacityProps & {
+  variant?: 'primary' | 'outline' | 'coral' | 'teal';
+  title: string;
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  title,
+  style,
+  ...props
+}) => {
+  const baseStyles = 'rounded-md px-4 py-2 items-center justify-center';
+  const variants = {
+    primary: 'bg-primary',
+    coral: 'bg-coral',
+    teal: 'bg-teal',
+    outline: 'border border-primary',
+  };
+
+  const textVariants = {
+    primary: 'text-white',
+    outline: 'text-primary',
+    coral: 'text-white',
+    teal: 'text-white',
+  };
+
+  return (
+    <TouchableOpacity
+      style={[tw`${baseStyles} ${variants[variant]}`, style]}
+      {...props}
+      activeOpacity={0.8}
+    >
+      <Text style={tw`${textVariants[variant]} text-base font-semibold`}>
+        {title}
+      </Text>
+    </TouchableOpacity>
+  );
+};

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,42 @@
+import tw from '@/lib/design/tw';
+import React from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+type InputProps = TextInputProps & {
+  variant?: 'default' | 'outlined';
+  type?: 'text' | 'email' | 'number' | 'password';
+};
+
+export const Input: React.FC<InputProps> = ({
+  variant = 'default',
+  type = 'text',
+  style,
+  ...props
+}) => {
+  const baseStyles =
+    'rounded-md px-3 py-2 text-base bg-white text-text border border-transparent';
+  const variants = {
+    default: 'border-transparent',
+    outlined: 'border border-neutral-300',
+  };
+
+  const keyboardTypeMap = {
+    text: 'default',
+    email: 'email-address',
+    number: 'numeric',
+    password: 'default',
+  } as const;
+
+  const isPassword = type === 'password';
+
+  return (
+    <TextInput
+      style={tw`${baseStyles} ${variants[variant]}`}
+      placeholderTextColor="#9CA3AF"
+      keyboardType={keyboardTypeMap[type]}
+      secureTextEntry={isPassword}
+      autoCapitalize="none"
+      {...props}
+    />
+  );
+};


### PR DESCRIPTION
### 🔍 What’s been done?

_A short summary of the issue and what was changed._

### Changes
- Added a reusable `Input` and "Button" component
- Supports `type` prop (`text`, `email`, `number`, `password`)
- Automatically maps `type` to `keyboardType` and `secureTextEntry`
- Styled using `twrnc` with tokens from the design system

### Why
This improves consistency across the app and makes it easier to build forms. The component is flexible, styled, and ready for future enhancements (e.g. validation, labels, error messages).


### ✅ Checklist

- [✅] Code is formatted & linted
- [✅] Only relevant files are changed
- [✅] PR title follows conventional commits (e.g. `fix:`, `feat:`, `docs:`)
- [✅] I’ve tested my changes and reviewed the diff before submitting

Closes #22 
